### PR TITLE
查看评论功能增强

### DIFF
--- a/comment.go
+++ b/comment.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Comment struct {
-	Rpid      int    `json:"rpid"`       // 评论 rpid
+	Rpid      int64  `json:"rpid"`       // 评论 rpid
 	Oid       int    `json:"oid"`        // 评论区对象 id
 	Type      int    `json:"type"`       // 评论区类型代码
 	Mid       int    `json:"mid"`        // 发送者 mid


### PR DESCRIPTION
原本的逻辑只能查看评论，及展开的二级评论; 新加功能：调用查询评论的方法带上root（即父级评论的Rpid）,就可以查看折叠的二级评论 ; root为0,则表示按原来的逻辑查看评论