### PR TITLE
[feature] #34 支持使用反射设置参数

### DIFF
--- a/util.go
+++ b/util.go
@@ -3,6 +3,11 @@ package bilibili
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
+	"strings"
+	"unicode"
+
+	"github.com/go-resty/resty/v2"
 	"github.com/pkg/errors"
 	"github.com/spf13/cast"
 )
@@ -84,4 +89,125 @@ func structToMap(s any, handlers ...paramHandler) (map[string]string, error) {
 		}
 	}
 	return m2, nil
+}
+
+func withParams(r *resty.Request, in any) error {
+	if in == nil {
+		return nil
+	}
+
+	inType := reflect.TypeOf(in)
+	inValue := reflect.ValueOf(in)
+
+	switch inType.Kind() {
+	case reflect.Ptr:
+		// 如果是空指针，直接返回
+		if inValue.IsNil() {
+			return nil
+		}
+		inType = inType.Elem()
+		inValue = inValue.Elem()
+	case reflect.Struct:
+	default:
+		return errors.New("参数类型错误")
+	}
+
+	bodyMap := make(map[string]interface{}, 4)
+	for i := 0; i < inType.NumField(); i++ {
+		fieldType := inType.Field(i)
+		fieldValue := inValue.Field(i)
+		tValue := fieldType.Tag.Get("request")
+
+		if tValue == "" || tValue == "-" {
+			continue
+		}
+
+		// 获取字段名
+		var fieldName string
+
+		tagMap := parseTag(tValue)
+		if name, ok := tagMap["field"]; ok {
+			fieldName = name
+		} else {
+			fieldName = toSnakeCase(fieldType.Name)
+		}
+
+		var realVal interface{}
+		if fieldType.Type.Kind() == reflect.Ptr {
+			// 设置 Ptr == nil 代表不传
+			if fieldValue.IsNil() {
+				continue
+			}
+			realVal = fieldValue.Elem().Interface()
+		} else {
+			if fieldValue.IsZero() {
+				// 设置了 omitempty 代表不传
+				if _, ok := tagMap["omitempty"]; ok {
+					continue
+				}
+				// 设置了 default 代表使用默认值
+				if v, ok := tagMap["default"]; ok {
+					realVal = v
+				} else {
+					// 否则使用零值
+					realVal = reflect.Zero(fieldType.Type).Interface()
+				}
+			} else {
+				realVal = fieldValue.Interface()
+			}
+		}
+
+		for name, _ := range tagMap {
+			switch name {
+			case "query":
+				r.SetQueryParam(fieldName, cast.ToString(realVal))
+			case "json":
+				r.SetHeader("Content-Type", "application/json")
+				bodyMap[fieldName] = realVal
+			case "form-data":
+				r.SetHeader("Content-Type", "application/x-www-form-urlencoded")
+				bodyMap[fieldName] = realVal
+			}
+		}
+	}
+
+	if len(bodyMap) > 0 {
+		r.SetBody(bodyMap)
+	}
+
+	return nil
+}
+
+func parseTag(tag string) map[string]string {
+	parts := strings.Split(tag, ",")
+
+	pMap := make(map[string]string, 10)
+	for _, part := range parts {
+		kv := strings.Split(part, "=")
+		if len(kv) == 1 {
+			pMap[kv[0]] = ""
+		} else {
+			pMap[kv[0]] = kv[1]
+		}
+	}
+
+	return pMap
+}
+
+func toSnakeCase(s string) string {
+	var result strings.Builder
+	result.Grow(len(s) * 2)
+
+	for i, r := range s {
+		if unicode.IsUpper(r) {
+			if i > 0 {
+				result.WriteRune('_')
+			}
+			result.WriteRune(unicode.ToLower(r))
+		} else {
+			result.WriteRune(r)
+		}
+	}
+
+	return result.String()
 }

--- a/util_test.go
+++ b/util_test.go
@@ -39,7 +39,7 @@ func TestStructToMap(t *testing.T) {
 	}
 }
 
-func Test_withParams(t *testing.T) {
+func TestWithParams(t *testing.T) {
 	type GetVideoCommentParams struct {
 		AccessKey string `json:"access_key,omitempty" request:"query"`       // APP 登录 Token，不是APP方式可以填空
 		Type      int    `json:"type" request:"query,default=1"`             // 评论区类型代码
@@ -52,6 +52,8 @@ func Test_withParams(t *testing.T) {
 		TestA string `json:"test_a,omitempty" request:"json,default=1"`
 		TestB string `json:"test_b,omitempty" request:"json,omitempty"`
 		TestC string `json:"test_c,omitempty" request:"form-data,field=TC"`
+		TestD string `json:"test_d,omitempty" request:"-"`
+		TestE string `json:"test_e,omitempty" request:"json"`
 	}
 
 	params := GetVideoCommentParams{
@@ -61,6 +63,7 @@ func Test_withParams(t *testing.T) {
 		Sort:      3,
 
 		TestC: "test_c",
+		TestD: "test_d",
 	}
 
 	r := resty.New().R()
@@ -90,7 +93,90 @@ func Test_withParams(t *testing.T) {
 	if !maps.Equal(r.Body.(map[string]interface{}), map[string]interface{}{
 		"test_a": "1",
 		"TC":     "test_c",
+		"test_e": "",
 	}) {
+		t.Fatal("withParams body result not correct ", r.Body)
+	}
+}
+
+func TestWithParams2(t *testing.T) {
+	type GetVideoCommentParams struct {
+		AccessKey string `json:"access_key,omitempty" request:"query"`       // APP 登录 Token，不是APP方式可以填空
+		Type      int    `json:"type" request:"query,default=1"`             // 评论区类型代码
+		Oid       int    `json:"oid" request:"query,default=2"`              // 目标评论区 id
+		Sort      int    `json:"sort,omitempty" request:"query,default=3"`   // 排序方式
+		Nohot     int    `json:"nohot,omitempty" request:"query,default=-1"` // 是否不显示热评
+		Ps        int    `json:"ps,omitempty" request:"query,default=20"`    // 每页项数
+		Pn        int    `json:"pn,omitempty" request:"query,default=1"`     // 页码
+
+		TestA string `json:"test_a,omitempty" request:"json,default=1"`
+		TestB string `json:"test_b,omitempty" request:"json,omitempty"`
+		TestC string `json:"test_c,omitempty" request:"form-data,field=TC"`
+		TestD string `json:"test_d,omitempty" request:"-"`
+		TestE string `json:"test_e,omitempty" request:"json"`
+	}
+
+	params := &GetVideoCommentParams{
+		AccessKey: "abc",
+		Type:      1,
+		Oid:       2,
+		Sort:      3,
+
+		TestC: "test_c",
+		TestD: "test_d",
+	}
+
+	r := resty.New().R()
+	err := withParams(r, params)
+
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	query := make(map[string]string)
+	for k := range r.QueryParam {
+		query[k] = r.QueryParam.Get(k)
+	}
+	if !maps.Equal(query, map[string]string{
+		"access_key": "abc",
+		"type":       "1",
+		"oid":        "2",
+		"sort":       "3",
+		"nohot":      "-1",
+		"ps":         "20",
+		"pn":         "1",
+	}) {
+		t.Fatal("withParams query result not correct ", r.QueryParam)
+	}
+
+	if !maps.Equal(r.Body.(map[string]interface{}), map[string]interface{}{
+		"test_a": "1",
+		"TC":     "test_c",
+		"test_e": "",
+	}) {
+		t.Fatal("withParams body result not correct ", r.Body)
+	}
+}
+
+func TestWithParams3(t *testing.T) {
+	r := resty.New().R()
+	err := withParams(r, []int{1, 2, 3})
+
+	if err == nil || err.Error() != "参数类型错误" {
+		t.Fatal(err)
+	}
+
+	err = withParams(r, nil)
+	if err != nil {
+		t.Fatal("nil params should not return error")
+	}
+
+	if len(r.QueryParam) != 0 {
+		t.Fatal("withParams query result not correct ", r.QueryParam)
+	}
+
+	if r.Body != nil && len(r.Body.(map[string]interface{})) != 0 {
 		t.Fatal("withParams body result not correct ", r.Body)
 	}
 }

--- a/util_test.go
+++ b/util_test.go
@@ -3,6 +3,8 @@ package bilibili
 import (
 	"maps"
 	"testing"
+
+	"github.com/go-resty/resty/v2"
 )
 
 func TestStructToMap(t *testing.T) {
@@ -34,5 +36,61 @@ func TestStructToMap(t *testing.T) {
 		"sort":       "3",
 	}) {
 		t.Fatal("structToMap result not correct ", m)
+	}
+}
+
+func Test_withParams(t *testing.T) {
+	type GetVideoCommentParams struct {
+		AccessKey string `json:"access_key,omitempty" request:"query"`       // APP 登录 Token，不是APP方式可以填空
+		Type      int    `json:"type" request:"query,default=1"`             // 评论区类型代码
+		Oid       int    `json:"oid" request:"query,default=2"`              // 目标评论区 id
+		Sort      int    `json:"sort,omitempty" request:"query,default=3"`   // 排序方式
+		Nohot     int    `json:"nohot,omitempty" request:"query,default=-1"` // 是否不显示热评
+		Ps        int    `json:"ps,omitempty" request:"query,default=20"`    // 每页项数
+		Pn        int    `json:"pn,omitempty" request:"query,default=1"`     // 页码
+
+		TestA string `json:"test_a,omitempty" request:"json,default=1"`
+		TestB string `json:"test_b,omitempty" request:"json,omitempty"`
+		TestC string `json:"test_c,omitempty" request:"form-data,field=TC"`
+	}
+
+	params := GetVideoCommentParams{
+		AccessKey: "abc",
+		Type:      1,
+		Oid:       2,
+		Sort:      3,
+
+		TestC: "test_c",
+	}
+
+	r := resty.New().R()
+	err := withParams(r, params)
+
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	query := make(map[string]string)
+	for k := range r.QueryParam {
+		query[k] = r.QueryParam.Get(k)
+	}
+	if !maps.Equal(query, map[string]string{
+		"access_key": "abc",
+		"type":       "1",
+		"oid":        "2",
+		"sort":       "3",
+		"nohot":      "-1",
+		"ps":         "20",
+		"pn":         "1",
+	}) {
+		t.Fatal("withParams query result not correct ", r.QueryParam)
+	}
+
+	if !maps.Equal(r.Body.(map[string]interface{}), map[string]interface{}{
+		"test_a": "1",
+		"TC":     "test_c",
+	}) {
+		t.Fatal("withParams body result not correct ", r.Body)
 	}
 }


### PR DESCRIPTION
支持使用反射设置 `resty.Request` 的参数
目前使用的tag情况
- `request` 使用此tag name进行解析
- `query` 代表参数附加到 query中
- `json`和 `form-data` 代表参数附加到 body中 会分别附加对应的content-type
- `omitempty` 标记为omitempty的参数在零值时不会被附加到参数中
- `field` 默认使用 struct.FieldName 转蛇形作为参数名, 如果指定了field 则使用field的声明
- `default` 默认值,在参数为零值且未标记omitempty的时候使用

目前的考虑
- default会默认使用string类型 在部分json的场合可能不合适,可以为int 和float类型参数做特别转换
- 单独使用field可能会导致设置时非常繁琐，在考虑是否使用query=xxx or json=xxx 这种方式