### PR TITLE
优化Cookies相关函数

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ cookiesString := client.GetCookiesString()
 
 // 设置cookiesString，就不需要登录操作了
 client.SetCookiesString(cookiesString)
+// 你也可以直接把浏览器的Cookie复制过来调用SetCookiesString，这样也可以不需要登录操作了
 ```
 
 ### 其它接口

--- a/client.go
+++ b/client.go
@@ -45,28 +45,24 @@ func (c *Client) GetCookiesString() string {
 	for _, cookie := range c.resty.Cookies {
 		cookieStrings = append(cookieStrings, cookie.String())
 	}
-	return strings.Join(cookieStrings, "\n")
+	return strings.Join(cookieStrings, "; ")
 }
 
 // SetCookiesString 设置Cookies，但是是字符串格式，配合 GetCookiesString 使用。有些功能必须登录或设置Cookies后才能使用。
+//
+// 你也可以将浏览器中的Cookie传入这个函数使用。
 func (c *Client) SetCookiesString(cookiesString string) {
-	c.resty.SetCookies((&resty.Response{RawResponse: &http.Response{Header: http.Header{
-		"Set-Cookie": strings.Split(cookiesString, "\n"),
-	}}}).Cookies())
-}
-
-// SetCookies 设置Cookies
-func (c *Client) SetCookies(cookies []*http.Cookie) {
-	c.resty.SetCookies(cookies)
-}
-
-// SetRawCookies 这个 RawCookie 可以直接从浏览器 request的header中复制出来，然后直接设置
-func (c *Client) SetRawCookies(rawCookies string) {
+	rawCookies := strings.ReplaceAll(cookiesString, "\n", "; ") // 兼容之前的换行符
 	header := http.Header{}
 	header.Add("Cookie", rawCookies)
 	req := http.Request{Header: header}
 
 	c.SetCookies(req.Cookies())
+}
+
+// SetCookies 设置cookies
+func (c *Client) SetCookies(cookies []*http.Cookie) {
+	c.resty.SetCookies(cookies)
 }
 
 // GetCookies 获取当前的cookies

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,34 @@
+package bilibili
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestCookie(t *testing.T) {
+	result := []*http.Cookie{
+		{Name: "a", Value: "1"},
+		{Name: "b", Value: "2"},
+	}
+	{
+		c := New()
+		c.SetCookiesString("a=1; b=2")
+		if c.GetCookiesString() != "a=1; b=2" {
+			t.Fail()
+		}
+		if !reflect.DeepEqual(c.GetCookies(), result) {
+			t.Fail()
+		}
+	}
+	{
+		c := New()
+		c.SetCookiesString("a=1\nb=2")
+		if c.GetCookiesString() != "a=1; b=2" {
+			t.Fail()
+		}
+		if !reflect.DeepEqual(c.GetCookies(), result) {
+			t.Fail()
+		}
+	}
+}


### PR DESCRIPTION
主要就是把`SetRawCookies`合入到`SetCookiesString`中去了，这样一来，方便之前使用这个库的调用者。

新的`GetCookiesString`的返回值以`"; "`分隔，但是`SetCookiesString`兼容以`"; "`和以`"\n"`分隔的。

另外增加了测试用例，并调整了方法注释和`README.md`文档。