### PR TITLE
支持如果结构体`request`tag中没有`field`，就去找`json`tag

### DIFF
--- a/user.go
+++ b/user.go
@@ -1,5 +1,7 @@
 package bilibili
 
+import "github.com/go-resty/resty/v2"
+
 type GetUserVideosParam struct {
 	Mid     int    `json:"mid"`                                         // 目标用户mid
 	Order   string `json:"order,omitempty" request:"query,omitempty"`   // 排序方式。默认为pubdate。最新发布：pubdate。最多播放：click。最多收藏：stow
@@ -132,4 +134,18 @@ func (c *Client) GetUserCard(param GetUserCardParam) (*UserCard, error) {
 		url    = "https://api.bilibili.com/x/web-interface/card"
 	)
 	return execute[*UserCard](c, method, url, param)
+}
+
+type CheckNickNameParam struct {
+	Nickname string `json:"nickName"` // 目标昵称。最长为16字符
+}
+
+// CheckNickName 检查昵称是否可注册
+func (c *Client) CheckNickName(param CheckNickNameParam) error {
+	const (
+		method = resty.MethodGet
+		url    = "https://passport.bilibili.com/web/generic/check/nickname"
+	)
+	_, err := execute[any](c, method, url, param)
+	return err
 }

--- a/util.go
+++ b/util.go
@@ -123,6 +123,8 @@ func withParams(r *resty.Request, in any) error {
 		tagMap := parseTag(tValue)
 		if name, ok := tagMap["field"]; ok {
 			fieldName = name
+		} else if jsonValue := fieldType.Tag.Get("json"); jsonValue != "" && jsonValue != "-" {
+			fieldName = jsonValue
 		} else {
 			fieldName = toSnakeCase(fieldType.Name)
 		}

--- a/util_test.go
+++ b/util_test.go
@@ -21,6 +21,7 @@ func TestQuery(t *testing.T) {
 		TestJ *int   `request:"query"`
 		TestK int    `request:"query"`
 		testL int    `request:"query"`
+		TestM string `json:"testM"`
 	}
 
 	f, i := 10, 0
@@ -57,6 +58,7 @@ func TestQuery(t *testing.T) {
 		"test_i": "0",
 		"test_j": "",
 		"test_k": "0",
+		"testM":  "",
 	}) {
 		t.Fatal("withParams query result not correct ", r.QueryParam)
 	}
@@ -76,6 +78,7 @@ func TestQueryPtr(t *testing.T) {
 		TestJ *int   `request:"query"`
 		TestK int    `request:"query"`
 		testL int    `request:"query"`
+		TestM string `json:"testM"`
 	}
 
 	f, i := 10, 0
@@ -112,6 +115,7 @@ func TestQueryPtr(t *testing.T) {
 		"test_i": "0",
 		"test_j": "",
 		"test_k": "0",
+		"testM":  "",
 	}) {
 		t.Fatal("withParams query result not correct ", r.QueryParam)
 	}
@@ -131,6 +135,7 @@ func TestJson(t *testing.T) {
 		TestJ *int   `request:"json"`
 		TestK int    `request:"json"`
 		testL int    `request:"json"`
+		TestM string `json:"testM" request:"json"`
 	}
 
 	f, i := 10, 0
@@ -163,6 +168,7 @@ func TestJson(t *testing.T) {
 		"test_i": &i,
 		"test_j": (*int)(nil),
 		"test_k": 0,
+		"testM":  "",
 	}) {
 		t.Fatal("withParams body result not correct ", r.Body)
 	}
@@ -182,6 +188,7 @@ func TestFormData(t *testing.T) {
 		TestJ *int   `request:"form-data"`
 		TestK int    `request:"form-data"`
 		testL int    `request:"form-data"`
+		TestM string `json:"testM" request:"form-data"`
 	}
 
 	f, i := 10, 0
@@ -214,6 +221,7 @@ func TestFormData(t *testing.T) {
 		"test_i": &i,
 		"test_j": (*int)(nil),
 		"test_k": 0,
+		"testM":  "",
 	}) {
 		t.Fatal("withParams body result not correct ", r.Body)
 	}


### PR DESCRIPTION
修改原因：B站的某些接口的参数名并非是蛇形命名的，例如：

> > https://passport.bilibili.com/web/generic/check/nickname
> 
> *请求方式:GET*
> 
> 也可用于判断指定昵称的用户是否存在
> 
> **url参数：**
> 
> | 参数名 | 类型 | 内容        | 必要性 | 备注 |
> | -------- | ---- | ----------- | ------ | ---- |
> | nickName | str | 目标昵称  | 必要   | 最长为16字符 |

目前的生成工具会生成出这样的结构体：

```go
type CheckNickNameParam struct {
	Nickname string `json:"nickName"` // 目标昵称。最长为16字符
}
```

我们原先的逻辑是：

```py
if 找到"request"tag中的"field"时:
    直接用这个
else:
    调用toSnakeCase
```

于是`toSnakeCase("Nickname")`就成了`"nickname"`，会出现参数错误请求失败。

鉴于改生成工具让它**视情况在需要的时候**生成`request:"query,field=nickName"`的逻辑比较麻烦，就直接改`withParams`函数吧，变成这样的逻辑：

```py
if 找到"request"tag中的"field"时:
    直接用这个
elif 找到"json"tag:
    直接用这个
else:
    调用toSnakeCase
```

涉及的那个接口也同时提交到这个pull request中了，可以参考。