### PR TITLE
降到Go1.19版本

### DIFF
--- a/.github/workflows/gofmt.yml
+++ b/.github/workflows/gofmt.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.19'
 
       - name: gofmt
         run: |

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.19'
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 如果你发现有**接口bug**或者**有你需要但是本库尚未实现的接口**，可以[提交issue](https://github.com/CuteReimu/bilibili/issues/new/choose)或者[提交pull request](#如何为仓库做贡献)。
 如果因为B站修改了接口导致接口突然不可用，不一定能够及时更新，很大程度上需要依赖各位的告知。
 
-现在是v2版本，v2版本使用了泛型，因此确认不支持Go1.17及之前的版本。[如果还想使用v1版本可以点击这里跳转](https://github.com/CuteReimu/bilibili/tree/v1)。
+现在是v2版本，v2版本需要Go1.19及以上。[如果还想使用v1版本可以点击这里跳转](https://github.com/CuteReimu/bilibili/tree/v1)。
 
 ## 声明
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/CuteReimu/bilibili/v2
 
-go 1.22
+go 1.19
 
 require (
 	github.com/Baozisoftware/qrcode-terminal-go v0.0.0-20170407111555-c0650d8dff0f

--- a/go.sum
+++ b/go.sum
@@ -1,15 +1,11 @@
 github.com/Baozisoftware/qrcode-terminal-go v0.0.0-20170407111555-c0650d8dff0f h1:2dk3eOnYllh+wUOuDhOoC2vUVoJF/5z478ryJ+wzEII=
 github.com/Baozisoftware/qrcode-terminal-go v0.0.0-20170407111555-c0650d8dff0f/go.mod h1:4a58ifQTEe2uwwsaqbh3i2un5/CBPg+At/qHpt18Tmk=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
-github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/go-resty/resty/v2 v2.12.0 h1:rsVL8P90LFvkUYq/V5BTVe203WfRIU4gvcf+yfzJzGA=
 github.com/go-resty/resty/v2 v2.12.0/go.mod h1:o0yGPrkS3lOe1+eFajk6kBW8ScXzwU3hD69/gt2yB/0=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
-github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
-github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
@@ -18,7 +14,6 @@ github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
-github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1vwZ3Je0FKVCfqOLp5zO6trqMLYs0=
 github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e/go.mod h1:XV66xRDqSt+GTGFMVlhk3ULuV0y9ZmzeVGR4mloJI3M=
 github.com/spf13/cast v1.6.0 h1:GEiTHELF+vaR5dhz3VqZfFSzZjYbgeKDpBxQVS4GYJ0=

--- a/util_test.go
+++ b/util_test.go
@@ -1,7 +1,6 @@
 package bilibili
 
 import (
-	"maps"
 	"testing"
 
 	"github.com/go-resty/resty/v2"
@@ -45,21 +44,16 @@ func TestQuery(t *testing.T) {
 		t.Fatal("withParams content type not correct ", r.Header.Get("Content-Type"))
 	}
 
-	query := make(map[string]string)
-	for k := range r.QueryParam {
-		query[k] = r.QueryParam.Get(k)
-	}
-	if !maps.Equal(query, map[string]string{
-		"test_a": "",
-		"tb":     "1",
-		"test_e": "1",
-		"test_f": "10",
-		"test_g": "1",
-		"test_i": "0",
-		"test_j": "",
-		"test_k": "0",
-		"testM":  "",
-	}) {
+	if len(r.QueryParam) != 9 ||
+		r.QueryParam.Get("test_a") != "" ||
+		r.QueryParam.Get("tb") != "1" ||
+		r.QueryParam.Get("test_e") != "1" ||
+		r.QueryParam.Get("test_f") != "10" ||
+		r.QueryParam.Get("test_g") != "1" ||
+		r.QueryParam.Get("test_i") != "0" ||
+		r.QueryParam.Get("test_j") != "" ||
+		r.QueryParam.Get("test_k") != "0" ||
+		r.QueryParam.Get("testM") != "" {
 		t.Fatal("withParams query result not correct ", r.QueryParam)
 	}
 }
@@ -102,21 +96,16 @@ func TestQueryPtr(t *testing.T) {
 		t.Fatal("withParams content type not correct ", r.Header.Get("Content-Type"))
 	}
 
-	query := make(map[string]string)
-	for k := range r.QueryParam {
-		query[k] = r.QueryParam.Get(k)
-	}
-	if !maps.Equal(query, map[string]string{
-		"test_a": "",
-		"tb":     "1",
-		"test_e": "1",
-		"test_f": "10",
-		"test_g": "1",
-		"test_i": "0",
-		"test_j": "",
-		"test_k": "0",
-		"testM":  "",
-	}) {
+	if len(r.QueryParam) != 9 ||
+		r.QueryParam.Get("test_a") != "" ||
+		r.QueryParam.Get("tb") != "1" ||
+		r.QueryParam.Get("test_e") != "1" ||
+		r.QueryParam.Get("test_f") != "10" ||
+		r.QueryParam.Get("test_g") != "1" ||
+		r.QueryParam.Get("test_i") != "0" ||
+		r.QueryParam.Get("test_j") != "" ||
+		r.QueryParam.Get("test_k") != "0" ||
+		r.QueryParam.Get("testM") != "" {
 		t.Fatal("withParams query result not correct ", r.QueryParam)
 	}
 }
@@ -159,17 +148,17 @@ func TestJson(t *testing.T) {
 		t.Fatal("withParams content type not correct ", r.Header.Get("Content-Type"))
 	}
 
-	if !maps.Equal(r.Body.(map[string]any), map[string]any{
-		"test_a": "",
-		"tb":     "1",
-		"test_e": "1",
-		"test_f": &f,
-		"test_g": "1",
-		"test_i": &i,
-		"test_j": (*int)(nil),
-		"test_k": 0,
-		"testM":  "",
-	}) {
+	body := r.Body.(map[string]any)
+	if len(body) != 9 ||
+		body["test_a"] != "" ||
+		body["tb"] != "1" ||
+		body["test_e"] != "1" ||
+		body["test_f"] != &f ||
+		body["test_g"] != "1" ||
+		body["test_i"] != &i ||
+		body["test_j"] != (*int)(nil) ||
+		body["test_k"] != 0 ||
+		body["testM"] != "" {
 		t.Fatal("withParams body result not correct ", r.Body)
 	}
 }
@@ -212,17 +201,17 @@ func TestFormData(t *testing.T) {
 		t.Fatal("withParams content type not correct ", r.Header.Get("Content-Type"))
 	}
 
-	if !maps.Equal(r.Body.(map[string]any), map[string]any{
-		"test_a": "",
-		"tb":     "1",
-		"test_e": "1",
-		"test_f": &f,
-		"test_g": "1",
-		"test_i": &i,
-		"test_j": (*int)(nil),
-		"test_k": 0,
-		"testM":  "",
-	}) {
+	body := r.Body.(map[string]any)
+	if len(body) != 9 ||
+		body["test_a"] != "" ||
+		body["tb"] != "1" ||
+		body["test_e"] != "1" ||
+		body["test_f"] != &f ||
+		body["test_g"] != "1" ||
+		body["test_i"] != &i ||
+		body["test_j"] != (*int)(nil) ||
+		body["test_k"] != 0 ||
+		body["testM"] != "" {
 		t.Fatal("withParams body result not correct ", r.Body)
 	}
 }
@@ -251,10 +240,9 @@ func TestWithParamsSlice(t *testing.T) {
 		query[k] = r.QueryParam.Get(k)
 	}
 
-	if !maps.Equal(query, map[string]string{
-		"ids":   "1,2,3",
-		"ids_a": "1,2,3",
-	}) {
+	if len(r.QueryParam) != 2 ||
+		r.QueryParam.Get("ids") != "1,2,3" ||
+		r.QueryParam.Get("ids_a") != "1,2,3" {
 		t.Fatal("withParams query result not correct ", r.QueryParam)
 	}
 }


### PR DESCRIPTION
resolve #51

涉及如下改动：

- `go.mod` 中的版本号降到1.19
- `util_test.go` 中不再使用`maps`包，而是直接手动一个一个比较
- 相关Github Actions都改成Go1.19
- `README.md`中声明我们需要Go1.19及以上