### PR TITLE
对B站返回的错误码进行处理

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,32 @@ videoInfo, err := client.GetVideoInfo(bilibili.VideoParam{
 
 方法都是按照对应功能的英文翻译命名的，因此你可以方便地使用IDE找到想要的方法，配合注释便能够知道如何使用。
 
+### 对B站返回的错误码进行处理
+
+因为B站的返回内容是这样的格式：
+
+```json
+{
+   "code": 0,
+   "message": "错误信息",
+   "data": {}
+}
+```
+
+而我们这个库的接口只会返回`data`数据和一个`error`，若`code`为`0`则`error`为`nil`，否则我们并不会把`code`和`message`字段直接返回。
+
+在一般情况下，调用者不太需要关心`code`和`message`字段，只需要关心是否有`error`即可。
+但如果你实在需要`code`和`message`字段，我们也提供了一个办法：
+
+```go
+videoInfo, err := client.GetVideoInfo(bilibili.VideoParam{
+    Aid: 12345678,
+})
+if e, ok := err.(bilibili.Error); !ok {
+    log.Println(e.Code(), e.Message())
+}
+```
+
 ### 可能用到的工具接口
 
 ```go

--- a/README.md
+++ b/README.md
@@ -183,8 +183,12 @@ videoInfo, err := client.GetVideoInfo(bilibili.VideoParam{
 videoInfo, err := client.GetVideoInfo(bilibili.VideoParam{
     Aid: 12345678,
 })
-if e, ok := err.(bilibili.Error); !ok {
-    log.Println(e.Code(), e.Message())
+if err != nil {
+    if e, ok := err.(bilibili.Error); ok {
+        log.Printf("错误码: %d, 错误信息: %s", e.Code(), e.Message())
+    } else {
+        log.Printf("%+v\n", err)		
+    }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -184,10 +184,11 @@ videoInfo, err := client.GetVideoInfo(bilibili.VideoParam{
     Aid: 12345678,
 })
 if err != nil {
-    if e, ok := err.(bilibili.Error); ok {
-        log.Printf("错误码: %d, 错误信息: %s", e.Code(), e.Message())
-    } else {
-        log.Printf("%+v\n", err)		
+	var e bilibili.Error
+    if errors.As(err, &e) { // B站返回的错误
+        log.Printf("错误码: %d, 错误信息: %s", e.Code, e.Message)
+    } else { // 不是B站返回的错误
+        log.Printf("%+v\n", err)
     }
 }
 ```

--- a/util.go
+++ b/util.go
@@ -72,7 +72,7 @@ func execute[Out any](c *Client, method, url string, in any, handlers ...paramHa
 		return out, errors.WithStack(err)
 	}
 	if cr.Code != 0 {
-		return out, &biliError{cr.Code, cr.Message}
+		return out, Error{Code: cr.Code, Message: cr.Message}
 	}
 	return cr.Data, errors.WithStack(err)
 }
@@ -215,25 +215,11 @@ func toSnakeCase(s string) string {
 	return result.String()
 }
 
-type Error interface {
-	error
-	Code() int
-	Message() string
+type Error struct {
+	Code    int
+	Message string
 }
 
-type biliError struct {
-	code    int
-	message string
-}
-
-func (e *biliError) Code() int {
-	return e.code
-}
-
-func (e *biliError) Message() string {
-	return e.message
-}
-
-func (e *biliError) Error() string {
-	return fmt.Sprintf("错误码: %d, 错误信息: %s", e.code, e.message)
+func (e Error) Error() string {
+	return fmt.Sprintf("错误码: %d, 错误信息: %s", e.Code, e.Message)
 }

--- a/util.go
+++ b/util.go
@@ -2,6 +2,7 @@ package bilibili
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"reflect"
 	"strings"
@@ -71,7 +72,7 @@ func execute[Out any](c *Client, method, url string, in any, handlers ...paramHa
 		return out, errors.WithStack(err)
 	}
 	if cr.Code != 0 {
-		return out, errors.Errorf("错误码: %d, 错误信息: %s", cr.Code, cr.Message)
+		return out, &biliError{cr.Code, cr.Message}
 	}
 	return cr.Data, errors.WithStack(err)
 }
@@ -212,4 +213,27 @@ func toSnakeCase(s string) string {
 	}
 
 	return result.String()
+}
+
+type Error interface {
+	error
+	Code() int
+	Message() string
+}
+
+type biliError struct {
+	code    int
+	message string
+}
+
+func (e *biliError) Code() int {
+	return e.code
+}
+
+func (e *biliError) Message() string {
+	return e.message
+}
+
+func (e *biliError) Error() string {
+	return fmt.Sprintf("错误码: %d, 错误信息: %s", e.code, e.message)
 }


### PR DESCRIPTION
## 修改原因

需求来自 @zhangguanzhang 的私信：

> 看到你的代码里
> 
> https://github.com/CuteReimu/bilibili/blob/7c9c1d1b03cf9f0bc5e273d27046da2bf11ae3e9/util.go#L51-L83
> 
> 
> 看到使用泛型封装的，如何所有接口的Data都是最根级别的话，也就是下面类似，泛型无法匿名，如何在`execute`里`json.Unmarshal`后判断`cr.Code`，
> 
> ```go
> type commonResp[T any] struct { 
>     Code    int    `json:"code"` 
>     Message string `json:"message"` 
>     Data    T      `json:"data"` 
> } 
> ```

我的理解是，他想要拿到这个`Code`字段，但是目前不太方便拿。于是我就修改了一下。

调用方法可以在[diff](https://github.com/CuteReimu/bilibili/pull/54/files)中参考我修改的`README.md`。

## 遗留问题

目前我们返回的`error`都封装了`errors.WithStack`，因此调用者可以使用`fmt.Printf("%+v", err)`方便地打印出错误堆栈信息。而新增的这个`error`并不包含堆栈信息。我想了一下并没有想到好的解决办法，但是鉴于这是唯一一处返回`bilibili.Error`的地方，也很容易查找出错误来源，所以还凑合。

各位有没有什么好的建议呢？