### PR TITLE
浏览器复制的cookies和`GetCookiesString`获取的有所不同

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ client.SetRawCookies("cookie1=xxx; cookie2=xxx")
 
 > [!NOTE]
 > - `GetCookiesString`和`SetCookiesString`使用的字符串是`"cookie1=xxx; expires=xxx; domain=xxx.com; path=/\ncookie2=xxx; expires=xxx; domain=xxx.com; path=/"`，包含过期时间、domain等一些其它信息，以`"\n"`分隔多个cookie
-> - `SetRawCookies`使用的字符串是`"cookie1=xxx; cookie2=xxx"`，以`"; "`分隔多个cookie，这和在浏览器F12里复制的一样
+> - `SetRawCookies`使用的字符串是`"cookie1=xxx; cookie2=xxx"`，只包含key=value，以`"; "`分隔多个cookie，这和在浏览器F12里复制的一样
 >
 > 请注意不要混用。
 

--- a/README.md
+++ b/README.md
@@ -145,10 +145,18 @@ if err == nil && result.Status == 0 {
 // 获取cookiesString，自行存储，方便下次启动程序时不需要重新登录
 cookiesString := client.GetCookiesString()
 
-// 设置cookiesString，就不需要登录操作了
+// 下次启动时，把存储的cookiesString设置进来，就不需要登录操作了
 client.SetCookiesString(cookiesString)
-// 你也可以直接把浏览器的Cookie复制过来调用SetCookiesString，这样也可以不需要登录操作了
+
+// 如果你是从浏览器request的header中直接复制出来的cookies，则改为调用SetRawCookies
+client.SetRawCookies("cookie1=xxx; cookie2=xxx")
 ```
+
+> [!NOTE]
+> - `GetCookiesString`和`SetCookiesString`使用的字符串是`"cookie1=xxx; expires=xxx; domain=xxx.com; path=/\ncookie2=xxx; expires=xxx; domain=xxx.com; path=/"`，包含过期时间、domain等一些其它信息，以`"\n"`分隔多个cookie
+> - `SetRawCookies`使用的字符串是`"cookie1=xxx; cookie2=xxx"`，以`"; "`分隔多个cookie，这和在浏览器F12里复制的一样
+>
+> 请注意不要混用。
 
 ### 其它接口
 

--- a/client.go
+++ b/client.go
@@ -45,14 +45,18 @@ func (c *Client) GetCookiesString() string {
 	for _, cookie := range c.resty.Cookies {
 		cookieStrings = append(cookieStrings, cookie.String())
 	}
-	return strings.Join(cookieStrings, "; ")
+	return strings.Join(cookieStrings, "\n")
 }
 
 // SetCookiesString 设置Cookies，但是是字符串格式，配合 GetCookiesString 使用。有些功能必须登录或设置Cookies后才能使用。
-//
-// 你也可以将浏览器中的Cookie传入这个函数使用。
 func (c *Client) SetCookiesString(cookiesString string) {
-	rawCookies := strings.ReplaceAll(cookiesString, "\n", "; ") // 兼容之前的换行符
+	c.resty.SetCookies((&resty.Response{RawResponse: &http.Response{Header: http.Header{
+		"Set-Cookie": strings.Split(cookiesString, "\n"),
+	}}}).Cookies())
+}
+
+// SetRawCookies 如果你是从浏览器request的header中直接复制出来的cookies，调用这个函数。
+func (c *Client) SetRawCookies(rawCookies string) {
 	header := http.Header{}
 	header.Add("Cookie", rawCookies)
 	req := http.Request{Header: header}

--- a/client_test.go
+++ b/client_test.go
@@ -2,32 +2,58 @@ package bilibili
 
 import (
 	"net/http"
-	"reflect"
+	"strings"
 	"testing"
 )
 
+func deepEquals(a, b []*http.Cookie) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Name != b[i].Name {
+			return false
+		}
+		if a[i].Value != b[i].Value {
+			return false
+		}
+		if a[i].Domain != b[i].Domain {
+			return false
+		}
+		if a[i].Path != b[i].Path {
+			return false
+		}
+	}
+	return true
+}
+
 func TestCookie(t *testing.T) {
-	result := []*http.Cookie{
-		{Name: "a", Value: "1"},
-		{Name: "b", Value: "2"},
+	{
+		result := []*http.Cookie{ // 不测试Expires，因为time.Time转化成string再转化回来会丢失单调时钟
+			{Name: "a", Value: "1", Domain: "bilibili.com", Path: "/"},
+			{Name: "b", Value: "2", Domain: "bilibili.com", Path: "/"},
+		}
+		s := make([]string, 0, len(result))
+		for _, cookie := range result {
+			s = append(s, cookie.String())
+		}
+		c := New()
+		c.SetCookiesString(strings.Join(s, "\n"))
+		if !deepEquals(result, c.GetCookies()) {
+			t.Fail()
+		}
 	}
 	{
+		result := []*http.Cookie{
+			{Name: "a", Value: "1"},
+			{Name: "b", Value: "2"},
+		}
 		c := New()
-		c.SetCookiesString("a=1; b=2")
-		if c.GetCookiesString() != "a=1; b=2" {
+		c.SetRawCookies("a=1; b=2")
+		if c.GetCookiesString() != "a=1\nb=2" {
 			t.Fail()
 		}
-		if !reflect.DeepEqual(c.GetCookies(), result) {
-			t.Fail()
-		}
-	}
-	{
-		c := New()
-		c.SetCookiesString("a=1\nb=2")
-		if c.GetCookiesString() != "a=1; b=2" {
-			t.Fail()
-		}
-		if !reflect.DeepEqual(c.GetCookies(), result) {
+		if !deepEquals(result, c.GetCookies()) {
 			t.Fail()
 		}
 	}


### PR DESCRIPTION
- 浏览器中复制的cookies的格式是`"cookie1=xxx; cookie2=xxx"`，以`"; "`分隔
- 我们原先的方法返回的格式是`"cookie1=xxx; expires=xxx; domain=xxx.com; path=/\ncookie2=xxx; expires=xxx; domain=xxx.com; path=/"`，包含了一些其它信息，以`"\n"`分隔

应该区分开。

目前代码有bug，调用`GetCookiesString`得到的是第二种格式（但是用`"; "`分隔），再去调用`SetCookiesString`会出错。

同时更新了测试用例，优化了一下`README.md`中的相关文档。