### PR TITLE
解决多次调用SetCookies会导致cookies越来越长的问题

### DIFF
--- a/client.go
+++ b/client.go
@@ -50,7 +50,7 @@ func (c *Client) GetCookiesString() string {
 
 // SetCookiesString 设置Cookies，但是是字符串格式，配合 GetCookiesString 使用。有些功能必须登录或设置Cookies后才能使用。
 func (c *Client) SetCookiesString(cookiesString string) {
-	c.resty.SetCookies((&resty.Response{RawResponse: &http.Response{Header: http.Header{
+	c.SetCookies((&resty.Response{RawResponse: &http.Response{Header: http.Header{
 		"Set-Cookie": strings.Split(cookiesString, "\n"),
 	}}}).Cookies())
 }
@@ -64,9 +64,22 @@ func (c *Client) SetRawCookies(rawCookies string) {
 	c.SetCookies(req.Cookies())
 }
 
+// SetCookie 设置单个cookie
+func (c *Client) SetCookie(cookie *http.Cookie) {
+	for i, c0 := range c.resty.Cookies {
+		if c0.Name == cookie.Name {
+			c.resty.Cookies[i] = cookie
+			return
+		}
+	}
+	c.resty.Cookies = append(c.resty.Cookies, cookie)
+}
+
 // SetCookies 设置cookies
 func (c *Client) SetCookies(cookies []*http.Cookie) {
-	c.resty.SetCookies(cookies)
+	for _, cookie := range cookies {
+		c.SetCookie(cookie)
+	}
 }
 
 // GetCookies 获取当前的cookies

--- a/util.go
+++ b/util.go
@@ -67,7 +67,7 @@ func execute[Out any](c *Client, method, url string, in any, handlers ...paramHa
 	if resp.StatusCode() != 200 {
 		return out, errors.Errorf("status code: %d", resp.StatusCode())
 	}
-	c.resty.SetCookies(resp.Cookies())
+	c.SetCookies(resp.Cookies())
 	var cr commonResp[Out]
 	if err = json.Unmarshal(resp.Body(), &cr); err != nil {
 		return out, errors.WithStack(err)


### PR DESCRIPTION
@yanyao2333 @RunsTp 

我简单改了一版。

因为Go1.19标准库里没有`slices`包，就自己写循环了。

---

*至于是否需要提供一个删除所有Cookies的函数，先不提供吧，如果真的需要也可以自行`c.Resty().Cookies = nil`来解决。*

*这让我想起了好笑的事情：*

https://github.com/CuteReimu/bilibili/blob/7f31348b0fcaed227f65294eb3c96146bc80f321/README.md?plain=1#L231-L233

>《 **但是不要做一些离谱的操作**~~（比如把Cookies删了）~~》