### PR TITLE
Change type of Name in CollectionMeta from int to string

### DIFF
--- a/video.go
+++ b/video.go
@@ -530,7 +530,7 @@ type CollectionMeta struct {
 	Covr        string `json:"covr"`        // 合集封面 URL
 	Description string `json:"description"` // 合集描述
 	Mid         int    `json:"mid"`         // UP 主 ID
-	Name        int    `json:"name"`        // 合集标题
+	Name        string `json:"name"`        // 合集标题
 	Ptime       int    `json:"ptime"`       // 发布时间。Unix 时间戳
 	SeasonId    int    `json:"season_id"`   // 合集 ID
 	Total       int    `json:"total"`       // 合集内视频数量


### PR DESCRIPTION
fix error: json: cannot unmarshal string into Go struct field CollectionMeta.data.meta.name of type int

我在尝试使用合集接口时，发现 CollectionMeta 结构中的 Name 字段是 int 类型，导致了上述报错。我将 Name 字段调整为 string 类型，请 review。