### PR TITLE
fix: wrong type of field in struct Dash

### DIFF
--- a/video.go
+++ b/video.go
@@ -678,8 +678,8 @@ type Durl struct {
 }
 type Dash struct {
 	Duration      int            `json:"duration"`        // 视频长度。秒值
-	Minbuffertime int            `json:"minBufferTime"`   // 1.5？
-	MinBufferTime int            `json:"min_buffer_time"` // 1.5？
+	Minbuffertime float64        `json:"minBufferTime"`   // 1.5？
+	MinBufferTime float64        `json:"min_buffer_time"` // 1.5？
 	Video         []AudioOrVideo `json:"video"`           // 视频流信息 同一清晰度可拥有 H.264 / H.265 / AV1 多种码流<br />**HDR 仅支持 H.265** |
 	Audio         []AudioOrVideo `json:"audio"`           // 伴音流信息。当视频没有音轨时，此项为 null
 	Dolby         Dolby          `json:"dolby"`           // 杜比全景声伴音信息


### PR DESCRIPTION
<!-- 请用方便理解的形式简短地描述一下这个pr所修改的内容 -->
<!-- 如果是对接口的新增或修改，请确保已经阅读了下方的 contributing guidelines -->

修改video.go/Dash 结构体的以下字段
```go
Minbuffertime int            `json:"minBufferTime"`   // 1.5？
MinBufferTime int            `json:"min_buffer_time"` // 1.5？
```

不再出现断言在 util.go:72 
```go
if err = json.Unmarshal(resp.Body(), &cr); err != nil {
		return out, errors.WithStack(err)
	}
```
时导致的
json: cannot unmarshal number 1.5 into Go struct field Dash.data.dash.minBufferTime of type int
